### PR TITLE
Add openssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV BOOT_JVM_OPTIONS "-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xv
 ENV CLJ_VERSION 1.9.0.391
 
 RUN \
-    apk add --update curl && \
-    rm -rf /var/cache/apk/*
+    apk add --no-cache curl openssh-client
 
 RUN \
     cd /usr/local/bin; \


### PR DESCRIPTION
Required for git dependencies in `deps.edn`.

Also using --no-cache instead of --update; ref https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache