### PR TITLE
Upgrade clojure to 1.10.3.1087 to support tools.build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ENV BOOT_AS_ROOT yes
 ENV BOOT_EMIT_TARGET no
 ENV BOOT_VERSION 2.8.2
 ENV BOOT_JVM_OPTIONS "-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none -XX:-OmitStackTraceInFastThrow"
-ENV CLJ_VERSION 1.10.0.411
+ENV CLJ_VERSION 1.10.3.1087
 
 RUN \
-  apk add --no-cache py-pip && pip install docker-compose
+  apk add --no-cache py-pip && pip install docker-compose==1.23.2
 
 RUN \
-  apk add --no-cache curl openssh-client
+  apk add --no-cache --update git curl openssh-client
 
 RUN \
   cd /usr/local/bin; \

--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ To pull private git repository, you can set a variable `$SSH_PRIVATE_KEY`, this 
 
 ### 1.3.1
  * SSH client basic configuration
+ 
+### 1.4.0
+ * Upgrade clojure to 1.10.3.1087 to support tools.build.


### PR DESCRIPTION
* 更新clojure版本，以支持 tools.build ，需要升级到 1.10.3.933 版本以上。（额外说明，clojure 1.11已经到了RC1版本，但还没给出linux的安装包，1.10.3.1087是当前可用的最高版本。）
* tools.build 依赖 git 软件包，把它安装上。
* pip 仓库上的 docker-compose 最新版本已经与本镜像底包中的docker版本不兼容，不安装最新的 docker-compose 版本，而指定安装上次打包时的版本。（docker-compose 不是本次工作关注的点，顺手升级还可以，要花费大力气处理的就不必要了。）